### PR TITLE
Fix: Tor Desktop binary refs

### DIFF
--- a/WalletWasabi.Standard/Helpers/IoHelpers.cs
+++ b/WalletWasabi.Standard/Helpers/IoHelpers.cs
@@ -60,7 +60,7 @@ namespace System.IO
 		{
 			try
 			{
-				ZipFile.ExtractToDirectory(src, dest);
+				ZipFile.ExtractToDirectory(src, dest, true);
 			}
 			catch (UnauthorizedAccessException)
 			{

--- a/WalletWasabi.Standard/WalletWasabi.Standard.csproj
+++ b/WalletWasabi.Standard/WalletWasabi.Standard.csproj
@@ -65,7 +65,7 @@
     <None Update="TorDaemons\tor-osx64.zip">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Update="TorDaemons\tor-win32.zip">
+    <None Update="TorDaemons\tor-win64.zip">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
There is no win32 binary variant for Tor. This must have been some rebase/merge error from upstream. Additionally, allowed the zip copier to overwrite as you want to be able to ship newer binaries, or add missing files (such as what I experienced after noticing win64 zip was not copying